### PR TITLE
attempt at adding mpi variants

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,16 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_mpimpich:
+        CONFIG: linux_64_mpimpich
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpinompi:
+        CONFIG: linux_64_mpinompi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpiopenmpi:
+        CONFIG: linux_64_mpiopenmpi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,8 +8,14 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_mpimpich:
+        CONFIG: osx_64_mpimpich
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpinompi:
+        CONFIG: osx_64_mpinompi
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpiopenmpi:
+        CONFIG: osx_64_mpiopenmpi
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_64_mpinompi.yaml
+++ b/.ci_support/linux_64_mpinompi.yaml
@@ -14,6 +14,12 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '4'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_mpimpich.yaml
+++ b/.ci_support/osx_64_mpimpich.yaml
@@ -1,0 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '12'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '12'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_mpinompi.yaml
+++ b/.ci_support/osx_64_mpinompi.yaml
@@ -1,0 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '12'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '12'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_mpiopenmpi.yaml
+++ b/.ci_support/osx_64_mpiopenmpi.yaml
@@ -14,6 +14,12 @@ cxx_compiler_version:
 - '12'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
 target_platform:
 - osx-64
 zip_keys:

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,7 +23,7 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling ['boa', 'conda-forge-ci-setup=3'] and conda-build."
+echo -e "\n\nInstalling ['conda-forge-ci-setup=3'] and conda-build."
 mamba install --update-specs --quiet --yes --channel conda-forge \
     conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: https://svalinn.github.io/DAGMC/
 
 Package license: BSD-2-Clause
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/dagmc-feedstock/blob/master/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/dagmc-feedstock/blob/main/LICENSE.txt)
 
 Summary: Direct Accelerated Geometry Toolkit
 
@@ -27,24 +27,52 @@ Current build status
     <td>
       <details>
         <summary>
-          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8921&branchName=master">
-            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dagmc-feedstock?branchName=master">
+          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8921&branchName=main">
+            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dagmc-feedstock?branchName=main">
           </a>
         </summary>
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_mpimpich</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8921&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dagmc-feedstock?branchName=master&jobName=linux&configuration=linux_64_" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8921&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dagmc-feedstock?branchName=main&jobName=linux&configuration=linux_64_mpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>linux_64_mpinompi</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8921&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dagmc-feedstock?branchName=master&jobName=osx&configuration=osx_64_" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8921&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dagmc-feedstock?branchName=main&jobName=linux&configuration=linux_64_mpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_mpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8921&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dagmc-feedstock?branchName=main&jobName=linux&configuration=linux_64_mpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8921&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dagmc-feedstock?branchName=main&jobName=osx&configuration=osx_64_mpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8921&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dagmc-feedstock?branchName=main&jobName=osx&configuration=osx_64_mpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8921&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dagmc-feedstock?branchName=main&jobName=osx&configuration=osx_64_mpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr>
@@ -72,16 +100,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `dagmc` can be installed with:
+Once the `conda-forge` channel has been enabled, `dagmc` can be installed with `conda`:
 
 ```
 conda install dagmc
 ```
 
-It is possible to list all of the versions of `dagmc` available on your platform with:
+or with `mamba`:
+
+```
+mamba install dagmc
+```
+
+It is possible to list all of the versions of `dagmc` available on your platform with `conda`:
 
 ```
 conda search dagmc --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search dagmc --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search dagmc --channel conda-forge
+
+# List packages depending on `dagmc`:
+mamba repoquery whoneeds dagmc --channel conda-forge
+
+# List dependencies of `dagmc`:
+mamba repoquery depends dagmc --channel conda-forge
 ```
 
 
@@ -99,10 +152,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,6 +4,12 @@
 # default options from
 # https://github.com/svalinn/DAGMC/blob/develop/cmake/DAGMC_macros.cmake
 
+export CONFIGURE_ARGS=""
+
+if [[ "$mpi" != "nompi" ]]; then
+  export CONFIGURE_ARGS="-DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc ${CONFIGURE_ARGS}"
+fi
+
 cmake -DBUILD_MCNP5=OFF \
       -DBUILD_MCNP6=OFF \
       -DBUILD_MCNP_PLOT=OFF \
@@ -27,7 +33,8 @@ cmake -DBUILD_MCNP5=OFF \
       -DBUILD_RPATH=ON \
       -DOUBLE_DOWN=OFF \
       -DMOAB_DIR="${PREFIX}" \
-      -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+      -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+      ${CONFIGURE_ARGS}
 make -j "${CPU_COUNT}"
 make install
 make test

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+mpi:
+  - nompi
+  - mpich
+  - openmpi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,6 @@ package:
 source:
   git_url: https://github.com/svalinn/DAGMC.git
   git_rev: v{{ version }}
-  # git_depth: 1 # (Defaults to -1/not shallow)
 
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,26 @@ source:
 
 
 build:
-  number: 4
+  number: 5
+
+  # add build string so packages can depend on
+  # mpi or nompi variants explicitly:
+  # `dagmc * mpi_mpich_*` for mpich
+  # `dagmc * mpi_openmpi_*` for any openmpi
+  # `dagmc * nompi_*` for no mpi
+
+  {% if mpi != 'nompi' %}
+  {% set mpi_prefix = "mpi_" + mpi %}
+  {% else %}
+  {% set mpi_prefix = "nompi" %}
+  {% endif %}
+  string: {{ mpi_prefix }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}
+
+  {% if mpi != 'nompi' %}
+  run_exports:
+    - {{ name }} * {{ mpi_prefix }}_*
+  {% endif %}
+
   skip: True  # [win]
 
 requirements:
@@ -21,13 +40,18 @@ requirements:
     - make
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ mpi }}  # [mpi != 'nompi']
   host:
     - eigen
-    - moab * nompi_tempest*
+    - moab * nompi_tempest*  # [mpi == 'nompi']
+    - moab * {{ mpi_prefix }}_tempest*  # [mpi != 'nompi']
+    - {{ mpi }}  # [mpi != 'nompi']
   run:
     - eigen
-    - moab * nompi_tempest*
+    - moab * nompi_tempest*  # [mpi == 'nompi']
+    - moab * {{ mpi_prefix }}_tempest*  # [mpi != 'nompi']
     - zlib
+    - {{ mpi }}  # [mpi != 'nompi']
 
 test:
    commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
   # add build string so packages can depend on
   # mpi or nompi variants explicitly:
   # `dagmc * mpi_mpich_*` for mpich
-  # `dagmc * mpi_openmpi_*` for any openmpi
+  # `dagmc * mpi_openmpi_*` for ßopenmpi
   # `dagmc * nompi_*` for no mpi
 
   {% if mpi != 'nompi' %}
@@ -25,7 +25,7 @@ build:
   {% else %}
   {% set mpi_prefix = "nompi" %}
   {% endif %}
-  string: {{ mpi_prefix }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}
+  string: {{ mpi_prefix }}_py{{ CONDA_PY }}h{{ PKG_HASH }}
 
   {% if mpi != 'nompi' %}
   run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
   # add build string so packages can depend on
   # mpi or nompi variants explicitly:
   # `dagmc * mpi_mpich_*` for mpich
-  # `dagmc * mpi_openmpi_*` for ßopenmpi
+  # `dagmc * mpi_openmpi_*` for openmpi
   # `dagmc * nompi_*` for no mpi
 
   {% if mpi != 'nompi' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   git_url: https://github.com/svalinn/DAGMC.git
   git_rev: v{{ version }}
-  git_depth: 1 # (Defaults to -1/not shallow)
+  # git_depth: 1 # (Defaults to -1/not shallow)
 
 
 build:


### PR DESCRIPTION
This is an attempt to add MPI variants to the DAGMC feedstock, mostly for the purpose of using them down the line in the OpenMC feedstock.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.