### PR TITLE
Prioritize nompi builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,14 @@
 {% set name = "dagmc" %}
 {% set version = "3.2.1" %}
+{% set build = 6 %}
+
+# ensure mpi is defined (needed for conda-smithy recipe-lint)
+{% set mpi = mpi or 'nompi' %}
+
+{% if mpi == 'nompi' %}
+# prioritize nompi variant via build number
+{% set build = build + 100 %}
+{% endif %}
 
 package:
   name: {{ name }}
@@ -11,7 +20,7 @@ source:
 
 
 build:
-  number: 5
+  number: {{ build }}
 
   # add build string so packages can depend on
   # mpi or nompi variants explicitly:
@@ -42,13 +51,11 @@ requirements:
     - {{ mpi }}  # [mpi != 'nompi']
   host:
     - eigen
-    - moab * nompi_tempest*  # [mpi == 'nompi']
-    - moab * {{ mpi_prefix }}_tempest*  # [mpi != 'nompi']
+    - moab * {{ mpi_prefix }}_tempest*
     - {{ mpi }}  # [mpi != 'nompi']
   run:
     - eigen
-    - moab * nompi_tempest*  # [mpi == 'nompi']
-    - moab * {{ mpi_prefix }}_tempest*  # [mpi != 'nompi']
+    - moab * {{ mpi_prefix }}_tempest*
     - zlib
     - {{ mpi }}  # [mpi != 'nompi']
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

-------
One issue I noticed with the recently implemented support for MPI variants is that right now the nompi build is not being prioritized. This seems to be the [recommended practice](https://conda-forge.org/docs/maintainer/knowledge_base.html#message-passing-interface-mpi) and is done in other MPI-enabled packages such as h5py and moab. This PR prioritizes the nompi build by increasing its build number relative to the mpi builds.