### PR TITLE
run_constrained on moab may resolve merge error

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ build:
 
 requirements:
   run_constrained:
-    - moab * {{ mpi_prefix }}_tempest_* >=9999999
+    - moab * {{ mpi_prefix }}_tempest_*
   build:
     - cmake
     - make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dagmc" %}
 {% set version = "3.2.1" %}
-{% set build = 8 %}
+{% set build = 9 %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,8 @@ build:
   skip: True  # [win]
 
 requirements:
+  run_constrained:
+    - moab * {{ mpi_prefix }}_tempest_* >=9999999
   build:
     - cmake
     - make


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Trying to address #15 

<!--
Please add any other relevant info below:
-->

The conda-forge gitter makes a few references to using `run_constrained` with unreasonably high package numbers to resolve this incompatible component merge error. I am not sure if I am interpreting this correctly. My changes build locally, but my previous PR also built locally just fine and didn't resolve the issue in the end.

@shimwell - can you read the [`run_constrained`](https://conda-forge.org/docs/maintainer/adding_pkgs.html#constraining-packages-at-runtime) documentation and let me know if I implemented it the way you would interpret that?